### PR TITLE
Add dialog to confirm user choice

### DIFF
--- a/timezone_detect.js
+++ b/timezone_detect.js
@@ -4,32 +4,50 @@
  *
  * @todo: Use Drupal.behaviors?
  */
-(function ($, Drupal, drupalSettings) {
+(function ($, Drupal, drupalSettings, jstz) {
 
-  $(document).ready(function () {
+  var behavior = Drupal.behaviors.timezoneDetect = {};
 
+  behavior.attach = function () {
     // Determine timezone from browser client using jsTimezoneDetect library.
     var tz = jstz.determine();
 
     if (tz.name() != drupalSettings.timezone_detect.current_timezone) {
-
-      // Post timezone to callback url via ajax.
-      $.ajax({
-        type: 'POST',
-        url: drupalSettings.path.baseUrl + 'timezone-detect/ajax/set-timezone',
-        dataType: 'json',
-        data: {
-          timezone: tz.name(),
-          token: drupalSettings.timezone_detect.token
-        }
-      });
-
-      // Set any timezone select on this page to the detected timezone.
-      $('select[name="timezone"] option[value="' + tz.name() + '"]')
-        .closest('select')
-        .val(tz.name());
+      behavior.showDialog(tz);
     }
+  }
 
-  });
+  behavior.showDialog = function (tz) {
+    var dialog = Drupal.dialog(Drupal.t('Would you like to change your timezone from @existing to @current?', {'@current': tz.name(), '@existing': drupalSettings.timezone_detect.current_timezone}), {
+      dialogClass: 'confirm-dialog',
+      resizable: false,
+      closeOnEscape: false,
+      width:600,
+      title:"do you want to publish this content ?",
+      create: function () {
+        // $(this).parent().find('.ui-dialog-titlebar-close').remove();
+      },
+      beforeClose: false,
+      close: function (event) {
+        $(event.target).remove();
+      }
+    });
 
-})(jQuery, Drupal, drupalSettings);
+    // Post timezone to callback url via ajax.
+    $.ajax({
+      type: 'POST',
+      url: drupalSettings.path.baseUrl + 'timezone-detect/ajax/set-timezone',
+      dataType: 'json',
+      data: {
+        timezone: tz.name(),
+        token: drupalSettings.timezone_detect.token
+      }
+    });
+
+    // Set any timezone select on this page to the detected timezone.
+    $('select[name="timezone"] option[value="' + tz.name() + '"]')
+      .closest('select')
+      .val(tz.name());
+  }
+
+})(jQuery, Drupal, window.drupalSettings, window.jstz);

--- a/timezone_detect.js
+++ b/timezone_detect.js
@@ -4,50 +4,98 @@
  *
  * @todo: Use Drupal.behaviors?
  */
-(function ($, Drupal, drupalSettings, jstz) {
+(function ($, Drupal, drupalSettings, cookies, jstz) {
 
   var behavior = Drupal.behaviors.timezoneDetect = {};
 
-  behavior.attach = function () {
+  behavior.attach = function (context) {
+    var $document = $(document, context).once('timezone-detect');
+    if (!$document.length) {
+      // Run only once.
+      return;
+    }
     // Determine timezone from browser client using jsTimezoneDetect library.
     var tz = jstz.determine();
+    var tz_ignored = cookies.get('timezone_detect_ignore');
 
-    if (tz.name() != drupalSettings.timezone_detect.current_timezone) {
+    if (!tz_ignored && tz.name() != drupalSettings.timezone_detect.current_timezone) {
       behavior.showDialog(tz);
     }
   }
 
   behavior.showDialog = function (tz) {
-    var dialog = Drupal.dialog(Drupal.t('Would you like to change your timezone from @existing to @current?', {'@current': tz.name(), '@existing': drupalSettings.timezone_detect.current_timezone}), {
+    var $dialog_content = $(
+      `<div>${Drupal.theme('timezoneDetectDialog', tz)}</div>`,
+    );
+    var dialog = Drupal.dialog($dialog_content, {
       dialogClass: 'confirm-dialog',
       resizable: false,
       closeOnEscape: false,
       width:600,
-      title:"do you want to publish this content ?",
+      title: Drupal.t("Timezone change detected"),
       create: function () {
         // $(this).parent().find('.ui-dialog-titlebar-close').remove();
       },
       beforeClose: false,
       close: function (event) {
         $(event.target).remove();
-      }
-    });
+      },
+      buttons: [
+        {
+          text: Drupal.t('Yes'),
+          click() {
+            // Post timezone to callback url via ajax.
+            $.ajax({
+              type: 'POST',
+              url: drupalSettings.path.baseUrl + 'timezone-detect/ajax/set-timezone',
+              dataType: 'json',
+              data: {
+                timezone: tz.name(),
+                token: drupalSettings.timezone_detect.token
+              }
+            });
 
-    // Post timezone to callback url via ajax.
-    $.ajax({
-      type: 'POST',
-      url: drupalSettings.path.baseUrl + 'timezone-detect/ajax/set-timezone',
-      dataType: 'json',
-      data: {
-        timezone: tz.name(),
-        token: drupalSettings.timezone_detect.token
-      }
-    });
-
-    // Set any timezone select on this page to the detected timezone.
-    $('select[name="timezone"] option[value="' + tz.name() + '"]')
-      .closest('select')
-      .val(tz.name());
+            // Set any timezone select on this page to the detected timezone.
+            $('select[name="timezone"] option[value="' + tz.name() + '"]')
+              .closest('select')
+              .val(tz.name());
+            $(this).dialog('close');
+          },
+        },
+        {
+          text: Drupal.t("No, don't ask me again"),
+          click() {
+            // Post timezone to callback url via ajax.
+            $.ajax({
+              type: 'POST',
+              url: drupalSettings.path.baseUrl + 'timezone-detect/ajax/set-cookie',
+              dataType: 'json',
+              data: {
+                token: drupalSettings.timezone_detect.token
+              }
+            });
+            $(this).dialog('close');
+          },
+        },
+      ],
+    }).showModal();
   }
 
-})(jQuery, Drupal, window.drupalSettings, window.jstz);
+  /**
+   * Theme function for timezone detect modal dialog.
+   *
+   * @return {string}
+   *   Markup for the node preview modal.
+   */
+  Drupal.theme.timezoneDetectDialog = function(tz) {
+    var text = Drupal.t('Would you like to set your timezone to @tz?', {'@tz': tz.name()});
+    if (drupalSettings.timezone_detect.current_timezone) {
+      text = Drupal.t('Would you like to update your timezone from @existing to @tz?', {'@existing': drupalSettings.timezone_detect.current_timezone,'@tz': tz.name()});
+    }
+
+    return `<p>${text}</p><small class="description">${Drupal.t(
+      'You can always update this setting from your user profile.',
+    )}</small>`;
+  };
+
+})(jQuery, Drupal, window.drupalSettings, window.Cookies, window.jstz);

--- a/timezone_detect.libraries.yml
+++ b/timezone_detect.libraries.yml
@@ -10,4 +10,5 @@ init:
     - core/drupal
     - core/drupalSettings
     - timezone_detect/jstz
-    - core/jquery.ui.dialog
+    - core/drupal.dialog.ajax
+    - core/js-cookie

--- a/timezone_detect.libraries.yml
+++ b/timezone_detect.libraries.yml
@@ -7,5 +7,7 @@ init:
     timezone_detect.js: {}
   dependencies:
     - core/jquery
+    - core/drupal
     - core/drupalSettings
     - timezone_detect/jstz
+    - core/jquery.ui.dialog

--- a/timezone_detect.module
+++ b/timezone_detect.module
@@ -4,20 +4,41 @@
  * Module provides automatic timezone detection via javascript.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\timezone_detect\TimezoneDetectInterface;
 use Drupal\user\UserInterface;
 
 /**
  * Implements hook_user_login().
  */
-function timezone_detect_user_login(UserInterface $account) {
+function timezone_detect_user_login(UserInterface $user) {
   $timezone_detect_settings = \Drupal::config('timezone_detect.settings');
-  if ($timezone_detect_settings->get('mode') === TimezoneDetectInterface::MODE_LOGIN || empty($account->timezone)) {
+  if ($timezone_detect_settings->get('mode') === TimezoneDetectInterface::MODE_LOGIN || empty($user->timezone)) {
     // Set session flag to update user's timezone. Note that we cannot add the
     // js directly from this function, as the user is redirected after this
     // hook fires.
     $_SESSION['timezone_detect']['update_timezone'] = TRUE;
   }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function timezone_detect_user_update(UserInterface $user) {
+  /** @var \Drupal\user\UserInterface $old_data */
+  $original = $user->original;
+  if ($original->getTimeZone() === $user->getTimeZone()) {
+    // No timezone update happened.
+    return;
+  }
+  if (\Drupal::currentUser()->id() === $user->id()) {
+
+  }
+  // Set a cookie to ignore automatic timezone detection. If the cookie exists
+  // then this will overwrite existing cookie and update the expiry time.
+  setcookie('timezone_detect_ignore', '1', strtotime('now + 3 months'), '/', \Drupal::request()->getHost(), TRUE);
+  // Unset the session variable to update timezone.
+  unset($_SESSION['timezone_detect']['update_timezone']);
 }
 
 /**

--- a/timezone_detect.routing.yml
+++ b/timezone_detect.routing.yml
@@ -11,3 +11,9 @@ timezone_detect.update_timezone:
     _controller: 'Drupal\timezone_detect\Controller\SetTimezoneController::updateTimezone'
   requirements:
     _user_is_logged_in: 'TRUE'
+timezone_detect.set_cookie:
+  path: 'timezone-detect/ajax/set-cookie'
+  defaults:
+    _controller: 'Drupal\timezone_detect\Controller\SetTimezoneController::setCookie'
+  requirements:
+    _user_is_logged_in: 'TRUE'


### PR DESCRIPTION
Added a Drupal dialog to confirm that the user wants to change their timezone automatically.

Added a new cookie `timezone_detect_ignore` which gets set when the user's timezone is updated. Currently using `now + 3 months` as the cookie expiry timestamp but this can later be configured from the admin side perhaps.

![timezone-dialog](https://user-images.githubusercontent.com/24897663/100291888-e932d080-2f76-11eb-9ef2-0aeb69dd4ee7.gif)

(Sorry the gif has lagged a bit at a point when the dialog appears for the first time. There I simply dismiss the dialog with the "X" button and load the homepage where I see the dialog again.) If the cookie is not set and the user's timezone is not the same as the detected one, then a dialog is shown. If the user clicks Yes then their timezone is set to the detected one. If they click No then the cookie gets set and they're not asked again.

![timezone-dialog-dontaskagain](https://user-images.githubusercontent.com/24897663/100292007-34e57a00-2f77-11eb-9c9b-981d94a0fdfe.gif)

(Here the gif lags again when the dialog is shown but I pressed on "No don't ask me again".)
